### PR TITLE
009-generate-preps-from-dependents

### DIFF
--- a/app/controllers/admin/preparations_controller.rb
+++ b/app/controllers/admin/preparations_controller.rb
@@ -49,6 +49,6 @@ class Admin::PreparationsController < AdminController
 
   private
   def preparation_params
-    params.require(:preparation).permit(:prep_type, :keyword, :instructions, :base_cost_in_cents)
+    params.require(:preparation).permit(:prep_type, :keyword, :instructions, :base_cost_in_cents, :variable, :priority)
   end
 end

--- a/app/controllers/admin/preparations_controller.rb
+++ b/app/controllers/admin/preparations_controller.rb
@@ -55,8 +55,8 @@ class Admin::PreparationsController < AdminController
       :keyword,
       :instructions,
       :base_cost_in_cents,
-      :variable_quantity,
-      :variable_action, 
+      :variable_quantity_type,
+      :variable_action,
       :priority
     )
   end

--- a/app/controllers/admin/preparations_controller.rb
+++ b/app/controllers/admin/preparations_controller.rb
@@ -49,6 +49,15 @@ class Admin::PreparationsController < AdminController
 
   private
   def preparation_params
-    params.require(:preparation).permit(:prep_type, :keyword, :instructions, :base_cost_in_cents, :variable, :priority)
+    params.require(:preparation).permit(
+      :prep_maintype,
+      :prep_subtype,
+      :keyword,
+      :instructions,
+      :base_cost_in_cents,
+      :variable_quantity,
+      :variable_action, 
+      :priority
+    )
   end
 end

--- a/app/controllers/dependent_assessment_controller.rb
+++ b/app/controllers/dependent_assessment_controller.rb
@@ -36,6 +36,11 @@ class DependentAssessmentController < ApplicationController
   def destroy
     @dependent = Dependent.find(params[:id])
     @dependent.destroy
+    generate_dependent_preps(current_user)
+      # re-run this method so that user_preps with prep_subtype gear_pet and
+      # gear_human are updated with the new quantity of dependents. This has
+      # the effect of reducing these user_preps' total_cost_in_cents to the
+      # appropriate amount given # of dependents.
     flash[:notice] = "Dependent Deleted"
     redirect_to user_path(current_user.id)
   end

--- a/app/controllers/dependent_assessment_controller.rb
+++ b/app/controllers/dependent_assessment_controller.rb
@@ -3,6 +3,7 @@ class DependentAssessmentController < ApplicationController
     @dependent = Dependent.new(dependent_params)
     @dependent.user_id = current_user.id
     if @dependent.save
+      generate_dependent_preps(current_user)
       flash[:success] = "Dependent Added"
       redirect_to user_path(current_user.id) # TODO: replace redirect w/ AJAX
     elsif @dependent.errors
@@ -19,7 +20,6 @@ class DependentAssessmentController < ApplicationController
     @dependent = Dependent.find(params[:id])
     @dependent.update_db_values(params)
     if @dependent.save
-      # generate_dependent_preps(current_user, @dependent)
       generate_dependent_preps(current_user)
       flash[:success] = "Dependent Updated"
       redirect_to user_path(current_user.id) # TODO: replace redirect w/ AJAX
@@ -50,11 +50,9 @@ class DependentAssessmentController < ApplicationController
     # How will I handle updating preps that are updated based on qty of dependents? (i.e. food, water)
 
     @pb = PrepBuilder.new(user)
+    @pb.generate_preps("gear_pet", options={consumer_multiplier: user.pets_in_household}) if user.pets_in_household > 0
+    @pb.generate_preps("gear_human", options = {consumer_multiplier: user.people_in_household})
     # @pb.generate_preps("plan")
-    # @pb.generate_preps("pet") if user.pets_in_household > 0
-
-    @pb.generate_preps("gear", options = {people_multiplier: user.people_in_household})
-    # raise
   end
 
   private

--- a/app/controllers/dependent_assessment_controller.rb
+++ b/app/controllers/dependent_assessment_controller.rb
@@ -54,6 +54,6 @@ class DependentAssessmentController < ApplicationController
 
   private
   def dependent_params
-    params.permit(:id, :human, :name)
+    params.require(:dependent).permit(:id, :human, :name)
   end
 end

--- a/app/controllers/dependent_assessment_controller.rb
+++ b/app/controllers/dependent_assessment_controller.rb
@@ -20,6 +20,7 @@ class DependentAssessmentController < ApplicationController
     @dependent.update_db_values(params)
     if @dependent.save
       # generate_dependent_preps(current_user, @dependent)
+      generate_dependent_preps(current_user)
       flash[:success] = "Dependent Updated"
       redirect_to user_path(current_user.id) # TODO: replace redirect w/ AJAX
     elsif @dependent.errors
@@ -39,18 +40,21 @@ class DependentAssessmentController < ApplicationController
     redirect_to user_path(current_user.id)
   end
 
-  def generate_dependent_preps(user, dependent)
+  def generate_dependent_preps(user)
     # NB: need to think through how I'm going to dynamically create gear & plan
     # preps based on each create/update of a Dependent
 
     # Things to consider:
+    # Do I even need to pass in @dependent if variable GPs and PPs are based on TOTAL # of dependents?
     # Are there certain preps that'll be created for *each* new dependent added?
     # How will I handle updating preps that are updated based on qty of dependents? (i.e. food, water)
 
-    # @pb = PrepBuilder.new(user)
-
+    @pb = PrepBuilder.new(user)
     # @pb.generate_preps("plan")
-    # @pb.generate_preps("gear")
+    # @pb.generate_preps("pet") if user.pets_in_household > 0
+
+    @pb.generate_preps("gear", options = {people_multiplier: user.people_in_household})
+    # raise
   end
 
   private

--- a/app/controllers/dependent_assessment_controller.rb
+++ b/app/controllers/dependent_assessment_controller.rb
@@ -41,14 +41,6 @@ class DependentAssessmentController < ApplicationController
   end
 
   def generate_dependent_preps(user)
-    # NB: need to think through how I'm going to dynamically create gear & plan
-    # preps based on each create/update of a Dependent
-
-    # Things to consider:
-    # Do I even need to pass in @dependent if variable GPs and PPs are based on TOTAL # of dependents?
-    # Are there certain preps that'll be created for *each* new dependent added?
-    # How will I handle updating preps that are updated based on qty of dependents? (i.e. food, water)
-
     @pb = PrepBuilder.new(user)
     @pb.generate_preps("gear_pet", options={consumer_multiplier: user.pets_in_household}) if user.pets_in_household > 0
     @pb.generate_preps("gear_human", options = {consumer_multiplier: user.people_in_household})

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,6 +35,12 @@ class UsersController < ApplicationController
 
   def update
     current_user.update(user_params)
+    d = DependentAssessmentController.new
+    d.generate_dependent_preps(current_user)
+    # re-run PrepBuilder (via DependentAssessmentController) for all of this
+    # user's UserPreps where total_cost varies based on user's # of days_to_cover
+    # TODO: run this same check but using a method on the user or user's
+    # UserPreps, not through DependentAssessmentController.
     flash[:success] = "User Updated"
     redirect_to user_path(current_user)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,12 +33,18 @@ class UsersController < ApplicationController
     load_assessment_data
   end
 
+  def update
+    current_user.update(user_params)
+    flash[:success] = "User Updated"
+    redirect_to user_path(current_user)
+  end
+
   def load_assessment_data
     @home = Home.load_home(current_user)
   end
 
   private
   def user_params
-    params.require(:user).permit(:username, :email, :password, :password_confirmation)
+    params.require(:user).permit(:username, :email, :password, :password_confirmation, :days_to_cover)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,6 +47,9 @@ class UsersController < ApplicationController
 
   def load_assessment_data
     @home = Home.load_home(current_user)
+    @dependent = Dependent.new
+    # ^^ this pre-loads a Dependent instance for creating a new Dependent; the
+    # form_helper that requires it is in _depdendent_assessment_form template
   end
 
   private

--- a/app/models/prep_builder.rb
+++ b/app/models/prep_builder.rb
@@ -20,7 +20,16 @@ class PrepBuilder
         instructions: p.instructions
       )
 
-      if p.variable_quantity
+      if p.variable_quantity_type == 'by_user' || p.variable_quantity_type == 'N/A'
+        @prep.update(total_cost_in_cents: (p.base_cost_in_cents))
+      elsif p.variable_quantity_type == 'by_dependent'
+        @prep.update(
+          total_cost_in_cents: (
+            p.base_cost_in_cents *
+            options[:consumer_multiplier]
+          )
+        )
+      elsif p.variable_quantity_type == 'by_day'
         @prep.update(
           total_cost_in_cents: (
             p.base_cost_in_cents *

--- a/app/models/prep_builder.rb
+++ b/app/models/prep_builder.rb
@@ -8,18 +8,17 @@ class PrepBuilder
     @user_id = user.id
   end
 
-  # def generate_preps(prep_type)
-  def generate_preps(prep_type, options)
-    Preparation.where(prep_type: prep_type).each do |p|
+  def generate_preps(prep_subtype, options)
+    Preparation.where(prep_subtype: prep_subtype).each do |p|
       @prep = UserPrep.find_or_create_by(
         user_id: user_id,
         prep_id: p.id,
         keyword: p.keyword,
-        prep_type: prep_type,
+        prep_type: prep_maintype,
         instructions: p.instructions
       )
 
-      if p.variable 
+      if p.variable
         @prep.update(
           total_cost_in_cents: (p.base_cost_in_cents * options[:people_multiplier])
         )

--- a/app/models/prep_builder.rb
+++ b/app/models/prep_builder.rb
@@ -1,3 +1,4 @@
+
 class PrepBuilder
   include ActiveModel::Model
   include ActiveModel::Validations
@@ -6,6 +7,7 @@ class PrepBuilder
 
   def initialize(user)
     @user_id = user.id
+    # @user = user
   end
 
   def generate_preps(prep_subtype, options)
@@ -14,14 +16,16 @@ class PrepBuilder
         user_id: user_id,
         prep_id: p.id,
         keyword: p.keyword,
-        prep_type: prep_maintype,
+        prep_type: p.prep_maintype,
         instructions: p.instructions
       )
 
-      if p.variable
+      if p.variable_quantity
         @prep.update(
-          total_cost_in_cents: (p.base_cost_in_cents * options[:people_multiplier])
+          # total_quantity_needed: (@user.days_to_cover)
+          total_cost_in_cents: (p.base_cost_in_cents * options[:consumer_multiplier]) # *total_quantity_needed || # @user.days_to_cover || prep.user.days_to_cover
         )
+        # raise
       end
     end
   end

--- a/app/models/prep_builder.rb
+++ b/app/models/prep_builder.rb
@@ -8,7 +8,8 @@ class PrepBuilder
     @user_id = user.id
   end
 
-  def generate_preps(prep_type)
+  # def generate_preps(prep_type)
+  def generate_preps(prep_type, options)
     Preparation.where(prep_type: prep_type).each do |p|
       @prep = UserPrep.find_or_create_by(
         user_id: user_id,
@@ -17,6 +18,12 @@ class PrepBuilder
         prep_type: prep_type,
         instructions: p.instructions
       )
+
+      if p.variable 
+        @prep.update(
+          total_cost_in_cents: (p.base_cost_in_cents * options[:people_multiplier])
+        )
+      end
     end
   end
 end

--- a/app/models/prep_builder.rb
+++ b/app/models/prep_builder.rb
@@ -22,10 +22,12 @@ class PrepBuilder
 
       if p.variable_quantity
         @prep.update(
-          # total_quantity_needed: (@user.days_to_cover)
-          total_cost_in_cents: (p.base_cost_in_cents * options[:consumer_multiplier]) # *total_quantity_needed || # @user.days_to_cover || prep.user.days_to_cover
+          total_cost_in_cents: (
+            p.base_cost_in_cents *
+            options[:consumer_multiplier] *
+            @prep.user.days_to_cover
+          )
         )
-        # raise
       end
     end
   end

--- a/app/models/prep_builder.rb
+++ b/app/models/prep_builder.rb
@@ -12,11 +12,12 @@ class PrepBuilder
 
   def generate_preps(prep_subtype, options)
     Preparation.where(prep_subtype: prep_subtype).each do |p|
-      @prep = UserPrep.find_or_create_by(
-        user_id: user_id,
+      @prep = UserPrep.where(user_id: user_id, keyword: p.keyword).first_or_create
+      @prep.update(
         prep_id: p.id,
         keyword: p.keyword,
-        prep_type: p.prep_maintype,
+        prep_maintype: p.prep_maintype,
+        prep_subtype: p.prep_subtype,
         instructions: p.instructions
       )
 

--- a/app/models/preparation.rb
+++ b/app/models/preparation.rb
@@ -1,4 +1,4 @@
 class Preparation < ApplicationRecord
-  validates_presence_of :prep_type, :keyword, :instructions
+  validates_presence_of :prep_maintype, :keyword, :instructions
   validates_uniqueness_of :keyword, :instructions
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,12 @@ class User < ApplicationRecord
   def has_dependents?
     true if self.dependents.count > 0
   end
+
+  def people_in_household
+    self.dependents.where(human: true).count + 1 # add 1 to count current_user!
+  end
+
+  def pets_in_household
+    self.dependents.where(human: false).count
+  end
 end

--- a/app/models/user_prep.rb
+++ b/app/models/user_prep.rb
@@ -1,6 +1,7 @@
 class UserPrep < ApplicationRecord
   validates_presence_of :instructions
   validates_uniqueness_of :keyword, scope: :user
-  validates_inclusion_of :prep_type, in: %w( home gear plan )
+  validates_inclusion_of :prep_maintype, in: %w( home gear plan )
+  # validates_inclusion_of :prep_subtype, in: %w( NB: TBD )
   belongs_to :user
 end

--- a/app/models/user_prep.rb
+++ b/app/models/user_prep.rb
@@ -1,6 +1,6 @@
 class UserPrep < ApplicationRecord
   validates_presence_of :instructions
   validates_uniqueness_of :keyword, scope: :user
-  validates_inclusion_of :prep_type, in: %w( home house gear plan )
+  validates_inclusion_of :prep_type, in: %w( home gear plan )
   belongs_to :user
 end

--- a/app/models/user_prep.rb
+++ b/app/models/user_prep.rb
@@ -2,6 +2,6 @@ class UserPrep < ApplicationRecord
   validates_presence_of :instructions
   validates_uniqueness_of :keyword, scope: :user
   validates_inclusion_of :prep_maintype, in: %w( home gear plan )
-  # validates_inclusion_of :prep_subtype, in: %w( NB: TBD )
+  validates_inclusion_of :prep_subtype, in: %w( home_structure home_interior gear_human gear_pet plan)
   belongs_to :user
 end

--- a/app/views/admin/edit.html.erb
+++ b/app/views/admin/edit.html.erb
@@ -1,30 +1,40 @@
 <h1> Edit Prep </h1>
 <%= form_for @preparation, url: admin_update_prep_path(@preparation) do |p| %>
-  <div class="form-group">
-    <%= p.label :prep_type, "Prep Type" %>
-    <%= p.select :prep_type, [['home'], ['house'], ['gear'], ['plan']]%>
-  </div>
-  <div class="form-group">
-    <%= p.label :instructions, "Instructions" %>
-    <%= p.text_field :instructions %>
-  </div>
-  <div class="form-group">
-    <%= p.label :keyword, "Keyword" %>
-    <%= p.text_field :keyword %>
-  </div>
-  <div class="form-group">
-    <%= p.label :base_cost_in_cents, "Base Cost" %>
-    <%= p.text_field :base_cost_in_cents %>
-  </div>
-  <div class="form-group">
-    <%= p.label :variable, 'Variable' %>
-    <%= p.radio_button :variable, true %>
-    <%= p.label :variable, 'Generic' %>
-    <%= p.radio_button :variable, false %>
-  </div>
-  <div class="form-group">
-    <%= p.label :priority, "Priority" %>
-    <%= p.select :priority, [['1'], ['2'], ['3'], ['4']]%>
-  </div>
+    <div class="form-group">
+      <%= p.label :prep_maintype, "Prep MainType" %>
+      <%= p.select :prep_maintype, [['home'], ['gear'], ['plan']]%>
+    </div>
+    <div class="form-group">
+      <%= p.label :prep_subtype, "Prep SubType" %>
+      <%= p.select :prep_subtype, [['home_interior'], ['home_structure'],['gear_human'], ['gear_pet']]%>
+    </div>
+    <div class="form-group">
+      <%= p.label :instructions, "Instructions" %>
+      <%= p.text_field :instructions %>
+    </div>
+    <div class="form-group">
+      <%= p.label :keyword, "Keyword" %>
+      <%= p.text_field :keyword %>
+    </div>
+    <div class="form-group">
+      <%= p.label :base_cost_in_cents, "Base Cost in Cents" %>
+      <%= p.text_field :base_cost_in_cents %>
+    </div>
+    <div class="form-group">
+      <%= p.label :variable_quantity, 'Variable Quantity' %>
+      <%= p.radio_button :variable_quantity, true %>
+      <%= p.label :variable_quantity, 'N/A' %>
+      <%= p.radio_button :variable_quantity, false %>
+    </div>
+    <div class="form-group">
+      <%= p.label :variable_action, 'Variable Action' %>
+      <%= p.radio_button :variable_action, true %>
+      <%= p.label :variable_action, 'N/A' %>
+      <%= p.radio_button :variable_action, false %>
+    </div>
+    <div class="form-group">
+      <%= p.label :priority, "Priority" %>
+      <%= p.select :priority, [['1'], ['2'], ['3'], ['4']]%>
+    </div>
   <%= p.submit %>
 <% end %>

--- a/app/views/admin/edit.html.erb
+++ b/app/views/admin/edit.html.erb
@@ -16,5 +16,15 @@
     <%= p.label :base_cost_in_cents, "Base Cost" %>
     <%= p.text_field :base_cost_in_cents %>
   </div>
+  <div class="form-group">
+    <%= p.label :variable, 'Variable' %>
+    <%= p.radio_button :variable, true %>
+    <%= p.label :variable, 'Generic' %>
+    <%= p.radio_button :variable, false %>
+  </div>
+  <div class="form-group">
+    <%= p.label :priority, "Priority" %>
+    <%= p.select :priority, [['1'], ['2'], ['3'], ['4']]%>
+  </div>
   <%= p.submit %>
 <% end %>

--- a/app/views/admin/edit.html.erb
+++ b/app/views/admin/edit.html.erb
@@ -6,7 +6,7 @@
     </div>
     <div class="form-group">
       <%= p.label :prep_subtype, "Prep SubType" %>
-      <%= p.select :prep_subtype, [['home_interior'], ['home_structure'],['gear_human'], ['gear_pet']]%>
+      <%= p.select :prep_subtype, [['home_interior'], ['home_structure'],['gear_human'], ['gear_pet'], ['plan']]%>
     </div>
     <div class="form-group">
       <%= p.label :instructions, "Instructions" %>
@@ -21,15 +21,17 @@
       <%= p.text_field :base_cost_in_cents %>
     </div>
     <div class="form-group">
-      <%= p.label :variable_quantity, 'Variable Quantity' %>
+      <div class="title title-form-group"> Variable Quantity </div>
+      <%= p.label :variable_quantity, 'True' %>
       <%= p.radio_button :variable_quantity, true %>
-      <%= p.label :variable_quantity, 'N/A' %>
+      <%= p.label :variable_quantity, 'False' %>
       <%= p.radio_button :variable_quantity, false %>
     </div>
     <div class="form-group">
-      <%= p.label :variable_action, 'Variable Action' %>
+      <div class="title title-form-group"> Variable Action </div>
+      <%= p.label :variable_action, 'True' %>
       <%= p.radio_button :variable_action, true %>
-      <%= p.label :variable_action, 'N/A' %>
+      <%= p.label :variable_action, 'False' %>
       <%= p.radio_button :variable_action, false %>
     </div>
     <div class="form-group">

--- a/app/views/admin/edit.html.erb
+++ b/app/views/admin/edit.html.erb
@@ -21,11 +21,8 @@
       <%= p.text_field :base_cost_in_cents %>
     </div>
     <div class="form-group">
-      <div class="title title-form-group"> Variable Quantity </div>
-      <%= p.label :variable_quantity, 'True' %>
-      <%= p.radio_button :variable_quantity, true %>
-      <%= p.label :variable_quantity, 'False' %>
-      <%= p.radio_button :variable_quantity, false %>
+      <%= p.label :variable_quantity_type, "Variable Quantity Type" %>
+      <%= p.select :variable_quantity_type, [['N/A'],['by_user'], ['by_dependent'], ['by_day']]%>
     </div>
     <div class="form-group">
       <div class="title title-form-group"> Variable Action </div>

--- a/app/views/admin/preparations.html.erb
+++ b/app/views/admin/preparations.html.erb
@@ -2,24 +2,28 @@
 <%= render "layouts/forms/new_prep_form"%>
 <table style="margin-top: 20px">
   <tr>
-    <th> Prep Type </th>
+    <th> Prep MainType </th>
+    <th> Prep SubType </th>
     <th> Instructions </th>
     <th> Keyword </th>
     <th> Base Cost </th>
     <th> Real Cost </th>
-    <th> Variable? </th>
+    <th> Variable Qty? </th>
+    <th> Variable Action? </th>
     <th> Priority </th>
     <th></th>
     <th></th>
   </tr>
   <% @preparations.each do |p|  %>
     <tr>
-      <td><%= p.prep_type %></td>
+      <td><%= p.prep_maintype %></td>
+      <td><%= p.prep_subtype %></td>
       <td><%= p.instructions %></td>
       <td><%= p.keyword %></td>
       <td><%= p.base_cost_in_cents       %></td>
       <td><%= p.base_cost_in_cents / 100 %></td>
-      <td><%= p.variable %></td>
+      <td><%= p.variable_quantity %></td>
+      <td><%= p.variable_action %></td>
       <td><%= p.priority %></td>
       <td><%= link_to "edit", admin_edit_prep_path(p) %></td>
       <td><%= link_to "x", admin_delete_prep_path(p) %></td>

--- a/app/views/admin/preparations.html.erb
+++ b/app/views/admin/preparations.html.erb
@@ -1,12 +1,14 @@
 <h1> Admin Dashboard </h1>
 <%= render "layouts/forms/new_prep_form"%>
-<table>
+<table style="margin-top: 20px">
   <tr>
     <th> Prep Type </th>
     <th> Instructions </th>
     <th> Keyword </th>
     <th> Base Cost </th>
     <th> Real Cost </th>
+    <th> Variable? </th>
+    <th> Priority </th>
     <th></th>
     <th></th>
   </tr>
@@ -17,8 +19,10 @@
       <td><%= p.keyword %></td>
       <td><%= p.base_cost_in_cents       %></td>
       <td><%= p.base_cost_in_cents / 100 %></td>
+      <td><%= p.variable %></td>
+      <td><%= p.priority %></td>
       <td><%= link_to "edit", admin_edit_prep_path(p) %></td>
-      <td><%= link_to "delete", admin_delete_prep_path(p) %></td>
+      <td><%= link_to "x", admin_delete_prep_path(p) %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/admin/preparations.html.erb
+++ b/app/views/admin/preparations.html.erb
@@ -8,7 +8,7 @@
     <th> Keyword </th>
     <th> Base Cost </th>
     <th> Real Cost </th>
-    <th> Variable Qty? </th>
+    <th> Variable Qty Type </th>
     <th> Variable Action? </th>
     <th> Priority </th>
     <th></th>
@@ -22,7 +22,7 @@
       <td><%= p.keyword %></td>
       <td><%= p.base_cost_in_cents       %></td>
       <td><%= p.base_cost_in_cents / 100 %></td>
-      <td><%= p.variable_quantity %></td>
+      <td><%= p.variable_quantity_type %></td>
       <td><%= p.variable_action %></td>
       <td><%= p.priority %></td>
       <td><%= link_to "edit", admin_edit_prep_path(p) %></td>

--- a/app/views/layouts/forms/_dependent_assessment_form.html.erb
+++ b/app/views/layouts/forms/_dependent_assessment_form.html.erb
@@ -25,23 +25,19 @@
   </ul>
 <% end %>
 <h3 class="title"> Add a Dependent </h3>
-<form action="/dependents/create" method="post">
-  <input name="utf8" type="hidden" value="✓">
-  <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>"/>
-  <div class="form-field">
-    <label for="name">Name</label>
-    <input type="text" class="text_field" name="name" id="name">
-  </div>
-  <div class="form-field" id="dep-type">
-    <label for="human">Human or Pet?</label>
-    <label>
-      <input type="radio" class="radio" name="human" id="human" value="true">
-      Human
-    </label>
-    <label>
-      <input type="radio" class="radio" name="human" id="human" value="false">
-      Pet
-    </label>
-  </div>
-  <input type="submit" value="Save Dependent">
-</form>
+<div class="create-dependent-form">
+  <%= form_for @dependent, url: create_dependent_path do |f| %>
+    <div class="form-group">
+      <%= f.label :name %>
+      <%= f.text_field :name %>
+    </div>
+    <div class="form-group">
+      <div class="title title-form-group"> Human or Pet? </div>
+      <%= f.label :human, 'Human' %>
+      <%= f.radio_button :human, true %>
+      <%= f.label :human, 'Pet' %>
+      <%= f.radio_button :human, false %>
+    </div>
+    <%= f.submit %>
+  <% end %>
+</div>

--- a/app/views/layouts/forms/_new_prep_form.html.erb
+++ b/app/views/layouts/forms/_new_prep_form.html.erb
@@ -16,5 +16,15 @@
     <%= p.label :base_cost_in_cents, "Base Cost in Cents" %>
     <%= p.text_field :base_cost_in_cents %>
   </div>
+  <div class="form-group">
+    <%= p.label :variable, 'Variable' %>
+    <%= p.radio_button :variable, true %>
+    <%= p.label :variable, 'Generic' %>
+    <%= p.radio_button :variable, false %>
+  </div>
+  <div class="form-group">
+    <%= p.label :priority, "Priority" %>
+    <%= p.select :priority, [['1'], ['2'], ['3'], ['4']]%>
+  </div>
   <%= p.submit %>
 <% end %>

--- a/app/views/layouts/forms/_new_prep_form.html.erb
+++ b/app/views/layouts/forms/_new_prep_form.html.erb
@@ -21,11 +21,8 @@
     <%= p.text_field :base_cost_in_cents %>
   </div>
   <div class="form-group">
-    <div class="title title-form-group"> Variable Quantity </div>
-    <%= p.label :variable_quantity, 'True' %>
-    <%= p.radio_button :variable_quantity, true %>
-    <%= p.label :variable_quantity, 'False' %>
-    <%= p.radio_button :variable_quantity, false %>
+    <%= p.label :variable_quantity_type, "Variable Quantity Type" %>
+    <%= p.select :variable_quantity_type, [['N/A'],['by_user'], ['by_dependent'], ['by_day']]%>
   </div>
   <div class="form-group">
     <div class="title title-form-group"> Variable Action </div>

--- a/app/views/layouts/forms/_new_prep_form.html.erb
+++ b/app/views/layouts/forms/_new_prep_form.html.erb
@@ -1,8 +1,12 @@
 <h2> Add a Preparation </h2>
 <%= form_for @preparation, url: admin_new_prep_path(@preparation) do |p| %>
   <div class="form-group">
-    <%= p.label :prep_type, "Prep Type" %>
-    <%= p.select :prep_type, [['home'], ['house'], ['gear'], ['plan']]%>
+    <%= p.label :prep_maintype, "Prep MainType" %>
+    <%= p.select :prep_maintype, [['home'], ['gear'], ['plan']]%>
+  </div>
+  <div class="form-group">
+    <%= p.label :prep_subtype, "Prep SubType" %>
+    <%= p.select :prep_subtype, [['home_interior'], ['home_structure'],['gear_human'], ['gear_pet']]%>
   </div>
   <div class="form-group">
     <%= p.label :instructions, "Instructions" %>
@@ -17,10 +21,16 @@
     <%= p.text_field :base_cost_in_cents %>
   </div>
   <div class="form-group">
-    <%= p.label :variable, 'Variable' %>
-    <%= p.radio_button :variable, true %>
-    <%= p.label :variable, 'Generic' %>
-    <%= p.radio_button :variable, false %>
+    <%= p.label :variable_quantity, 'Variable Quantity' %>
+    <%= p.radio_button :variable_quantity, true %>
+    <%= p.label :variable_quantity, 'N/A' %>
+    <%= p.radio_button :variable_quantity, false %>
+  </div>
+  <div class="form-group">
+    <%= p.label :variable_action, 'Variable Action' %>
+    <%= p.radio_button :variable_action, true %>
+    <%= p.label :variable_action, 'N/A' %>
+    <%= p.radio_button :variable_action, false %>
   </div>
   <div class="form-group">
     <%= p.label :priority, "Priority" %>

--- a/app/views/layouts/forms/_new_prep_form.html.erb
+++ b/app/views/layouts/forms/_new_prep_form.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="form-group">
     <%= p.label :prep_subtype, "Prep SubType" %>
-    <%= p.select :prep_subtype, [['home_interior'], ['home_structure'],['gear_human'], ['gear_pet']]%>
+    <%= p.select :prep_subtype, [['home_interior'], ['home_structure'],['gear_human'], ['gear_pet'], ['plan']]%>
   </div>
   <div class="form-group">
     <%= p.label :instructions, "Instructions" %>
@@ -21,15 +21,17 @@
     <%= p.text_field :base_cost_in_cents %>
   </div>
   <div class="form-group">
-    <%= p.label :variable_quantity, 'Variable Quantity' %>
+    <div class="title title-form-group"> Variable Quantity </div>
+    <%= p.label :variable_quantity, 'True' %>
     <%= p.radio_button :variable_quantity, true %>
-    <%= p.label :variable_quantity, 'N/A' %>
+    <%= p.label :variable_quantity, 'False' %>
     <%= p.radio_button :variable_quantity, false %>
   </div>
   <div class="form-group">
-    <%= p.label :variable_action, 'Variable Action' %>
+    <div class="title title-form-group"> Variable Action </div>
+    <%= p.label :variable_action, 'True' %>
     <%= p.radio_button :variable_action, true %>
-    <%= p.label :variable_action, 'N/A' %>
+    <%= p.label :variable_action, 'False' %>
     <%= p.radio_button :variable_action, false %>
   </div>
   <div class="form-group">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,12 @@
 <h1> My Profile </h1>
 <div class="profile-block">
+  <%= form_for current_user, url: update_user_path(current_user) do |f| %>
+    <div class="form-group">
+      <%= f.label :days_to_cover, "# of days you want your gear to last" %>
+      <%= f.text_field :days_to_cover %>
+      <%= f.submit %>
+    </div>
+  <% end %>
   <%= render "layouts/forms/home_assessment_form" %>
   <%= render "layouts/forms/dependent_assessment_form" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get "/sign-up",        to: "users#sign_up", as: :sign_up
   post "users",          to: "users#create",  as: :users
   get "/users/:id",      to: "users#show",    as: :user # AKA Profile
+  patch "/users/:id/update", to: "users#update", as: :update_user
 
   # PROFILE - ASSESSMENTS
   post  "/update_home",            to: "home_assessment#update_home"

--- a/db/migrate/20161027180901_add_columns_to_preparations.rb
+++ b/db/migrate/20161027180901_add_columns_to_preparations.rb
@@ -1,0 +1,6 @@
+class AddColumnsToPreparations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :preparations, :variable, :boolean
+    add_column :preparations, :priority, :integer
+  end
+end

--- a/db/migrate/20161027205745_add_var_qty_var_act_prep_subtype_to_preparations.rb
+++ b/db/migrate/20161027205745_add_var_qty_var_act_prep_subtype_to_preparations.rb
@@ -1,0 +1,8 @@
+class AddVarQtyVarActPrepSubtypeToPreparations < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :preparations, :prep_type, :prep_maintype
+    add_column :preparations, :prep_subtype, :string
+    rename_column :preparations, :variable, :variable_quantity
+    add_column :preparations, :variable_action, :boolean
+  end
+end

--- a/db/migrate/20161027231707_add_days_covered_to_user.rb
+++ b/db/migrate/20161027231707_add_days_covered_to_user.rb
@@ -1,0 +1,5 @@
+class AddDaysCoveredToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :days_to_cover, :integer
+  end
+end

--- a/db/migrate/20161028152838_change_preparation_var_qty_column.rb
+++ b/db/migrate/20161028152838_change_preparation_var_qty_column.rb
@@ -1,0 +1,6 @@
+class ChangePreparationVarQtyColumn < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :preparations, :variable_quantity, :variable_quantity_type
+    change_column :preparations, :variable_quantity_type, :string
+  end
+end

--- a/db/migrate/20161028160734_add_prep_subtype_to_user_preps.rb
+++ b/db/migrate/20161028160734_add_prep_subtype_to_user_preps.rb
@@ -1,0 +1,6 @@
+class AddPrepSubtypeToUserPreps < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :user_preps, :prep_type, :prep_maintype
+    add_column :user_preps, :prep_subtype, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161027180901) do
+ActiveRecord::Schema.define(version: 20161027205745) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,14 +40,16 @@ ActiveRecord::Schema.define(version: 20161027180901) do
   end
 
   create_table "preparations", force: :cascade do |t|
-    t.string   "prep_type"
+    t.string   "prep_maintype"
     t.string   "keyword"
     t.string   "instructions"
     t.integer  "base_cost_in_cents"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
-    t.boolean  "variable"
+    t.boolean  "variable_quantity"
     t.integer  "priority"
+    t.string   "prep_subtype"
+    t.boolean  "variable_action"
   end
 
   create_table "user_preps", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161028152838) do
+ActiveRecord::Schema.define(version: 20161028160734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 20161028152838) do
   create_table "user_preps", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "prep_id"
-    t.string   "prep_type"
+    t.string   "prep_maintype"
     t.string   "keyword"
     t.text     "note"
     t.integer  "total_cost_in_cents"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20161028152838) do
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
     t.string   "instructions"
+    t.string   "prep_subtype"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161027231707) do
+ActiveRecord::Schema.define(version: 20161028152838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,9 +44,9 @@ ActiveRecord::Schema.define(version: 20161027231707) do
     t.string   "keyword"
     t.string   "instructions"
     t.integer  "base_cost_in_cents"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
-    t.boolean  "variable_quantity"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.string   "variable_quantity_type"
     t.integer  "priority"
     t.string   "prep_subtype"
     t.boolean  "variable_action"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161026193735) do
+ActiveRecord::Schema.define(version: 20161027180901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,8 @@ ActiveRecord::Schema.define(version: 20161026193735) do
     t.integer  "base_cost_in_cents"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
+    t.boolean  "variable"
+    t.integer  "priority"
   end
 
   create_table "user_preps", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161027205745) do
+ActiveRecord::Schema.define(version: 20161027231707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 20161027205745) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.boolean  "admin"
+    t.integer  "days_to_cover"
   end
 
 end

--- a/spec/controllers/dependent_assessment_controller_spec.rb
+++ b/spec/controllers/dependent_assessment_controller_spec.rb
@@ -5,12 +5,20 @@ describe DependentAssessmentController, type: :controller do
 
   describe "POST #create" do
     let(:user) { create(:user) }
+
     before(:each) do
       stub_current_user(user)
     end
 
     context "with invalid attributes" do
+      let(:make_request) {
+        post :create, params: {dependent: attributes_for(:dependent, :human, name: nil)}
+      }
 
+      it "renders a descriptive error message" do
+        make_request
+        expect(flash[:error]).to include "name: can't be blank"
+      end
     end
 
     context "with valid attributes; Dependent is a HUMAN" do
@@ -23,29 +31,45 @@ describe DependentAssessmentController, type: :controller do
       end
 
       it "returns a descriptive success message" do
-
+        make_request
+        expect(flash[:success]).to include "Dependent Added"
       end
 
       it "redirects to current_user's profile" do
-
+        make_request
+        expect(response).to redirect_to user_path(user.id)
       end
 
       it "generates gear_human gear preps" do
-
+        preparation_gear_human = create(:gear_human)
+        make_request
+        expect(user.user_preps.where(prep_subtype: 'gear_human').count).to eq 1
       end
 
       it "does not generate any gear_pet gear preps" do
-
+        make_request
+        expect(user.user_preps.where(prep_subtype: 'gear_pet').count).to eq 0
       end
     end
 
     context "with valid attributes; Dependent is a PET" do
-      it "generates gear_pet gear preps" do
+      let(:make_request) {
+        post :create, params: {dependent: attributes_for(:dependent, :pet)}
+      }
 
+      it "generates gear_pet gear preps" do
+        preparation_gear_pet =  create(:gear_pet)
+        make_request
+        expect(user.user_preps.where(prep_subtype: 'gear_pet').count).to eq 1
+      end
+
+      it "does not generate any gear_human gear preps" do
+        make_request
+        expect(user.user_preps.where(prep_subtype: 'gear_human').count).to eq 0
       end
     end
 
-    context "with valid attributes; two PET Dependents" do
+    context "with valid attributes; two PET Dependents" do # This context is to test that the total_cost_in_cents of a given user_prep is updated based on qty of dependents
       it "passes in correct # of Pets for consumer_multiplier as
       reflected in double quantities of gear_pet gear preps" do
 

--- a/spec/controllers/dependent_assessment_controller_spec.rb
+++ b/spec/controllers/dependent_assessment_controller_spec.rb
@@ -70,9 +70,19 @@ describe DependentAssessmentController, type: :controller do
     end
 
     context "with valid attributes; two PET Dependents" do # This context is to test that the total_cost_in_cents of a given user_prep is updated based on qty of dependents
+      let(:make_first_request) {
+        post :create, params: {dependent: attributes_for(:dependent, :pet)}
+      }
+      let(:make_second_request) {
+        post :create, params: {dependent: attributes_for(:dependent, :pet, name: "dog")}
+      }
       it "passes in correct # of Pets for consumer_multiplier as
       reflected in double quantities of gear_pet gear preps" do
-
+        gear_pet_base_preparation = create(:gear_pet) # instantiate the Preparation with the base cost data
+        make_first_request
+        make_second_request # create two dependents so that the total cost of the user_prep is doubled.
+        variable_qty_user_prep = user.user_preps.where(prep_subtype:'gear_pet').first # isolate the user_prep to be checked
+        expect(variable_qty_user_prep.total_cost_in_cents).to eq(gear_pet_base_preparation.base_cost_in_cents * user.dependents.count) # confirm the total_cost is double the base_cost
       end
     end
   end

--- a/spec/controllers/dependent_assessment_controller_spec.rb
+++ b/spec/controllers/dependent_assessment_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+require 'pry'
+
+describe DependentAssessmentController, type: :controller do
+
+  describe "POST #create" do
+    let(:user) { create(:user) }
+    before(:each) do
+      stub_current_user(user)
+    end
+
+    context "with invalid attributes" do
+
+    end
+
+    context "with valid attributes; Dependent is a HUMAN" do
+      let(:make_request) {
+        post :create, params: {dependent: attributes_for(:dependent, :human)}
+      }
+
+      it "creates a new Dependent" do
+        expect { make_request }.to change(Dependent, :count).by(1)
+      end
+
+      it "returns a descriptive success message" do
+
+      end
+
+      it "redirects to current_user's profile" do
+
+      end
+
+      it "generates gear_human gear preps" do
+
+      end
+
+      it "does not generate any gear_pet gear preps" do
+
+      end
+    end
+
+    context "with valid attributes; Dependent is a PET" do
+      it "generates gear_pet gear preps" do
+
+      end
+    end
+
+    context "with valid attributes; two PET Dependents" do
+      it "passes in correct # of Pets for consumer_multiplier as
+      reflected in double quantities of gear_pet gear preps" do
+
+      end
+    end
+  end
+end

--- a/spec/factories/preparations.rb
+++ b/spec/factories/preparations.rb
@@ -1,12 +1,12 @@
 FactoryGirl.define do
   factory :preparation do
-    prep_type "home"
+    prep_maintype "home"
     keyword "keyword"
     instructions "instructions"
     base_cost_in_cents 100
 
     factory :home_prep do
-      prep_type "home"
+      prep_subtype "home"
       keyword "foundation"
       instructions "anchor home frame to foundation"
       base_cost_in_cents 400000

--- a/spec/factories/preparations.rb
+++ b/spec/factories/preparations.rb
@@ -6,10 +6,27 @@ FactoryGirl.define do
     base_cost_in_cents 100
 
     factory :home_prep do
-      prep_subtype "home"
+      prep_maintype "home"
+      prep_subtype "home_structure"
       keyword "foundation"
       instructions "anchor home frame to foundation"
       base_cost_in_cents 400000
+    end
+
+    factory :gear_human do
+      prep_maintype "gear"
+      prep_subtype "gear_human"
+      keyword "map"
+      instructions "local map"
+      base_cost_in_cents 500
+    end
+
+    factory :gear_pet do
+      prep_maintype "gear"
+      prep_subtype "gear_pet"
+      keyword "pet_food"
+      instructions "nonperishable pet food"
+      base_cost_in_cents 200
     end
   end
 end

--- a/spec/factories/preparations.rb
+++ b/spec/factories/preparations.rb
@@ -11,14 +11,16 @@ FactoryGirl.define do
       keyword "foundation"
       instructions "anchor home frame to foundation"
       base_cost_in_cents 400000
+      variable_quantity_type "by_user"
     end
 
     factory :gear_human do
       prep_maintype "gear"
       prep_subtype "gear_human"
-      keyword "map"
-      instructions "local map"
-      base_cost_in_cents 500
+      keyword "headlamp"
+      instructions "put a headlamp next to bedside of each person in home"
+      base_cost_in_cents 1500
+      variable_quantity_type "by_dependent"
     end
 
     factory :gear_pet do
@@ -27,6 +29,7 @@ FactoryGirl.define do
       keyword "pet_food"
       instructions "nonperishable pet food"
       base_cost_in_cents 200
+      variable_quantity_type "by_day"
     end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
     email { "#{username}@rc.com" }
     password "secret"
     password_confirmation "secret"
+    days_to_cover 1
 
     trait :admin do
       admin true

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -11,6 +11,4 @@ FactoryGirl.define do
       admin true
     end
   end
-
-
 end

--- a/spec/factories/user_preps.rb
+++ b/spec/factories/user_preps.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
   factory :user_prep do
     user
-    # user_id 1
     prep_maintype "plan"
     prep_subtype "plan"
     total_cost_in_cents 1
@@ -9,11 +8,24 @@ FactoryGirl.define do
     instructions "placeholder instructions"
 
     trait :home_prep do
-    # factory :home_user_prep do
-      # user_id 1
       prep_maintype "home"
       keyword "foundation"
       instructions "anchor home frame to foundation"
     end
+
+    factory :gear_prep do
+      prep_maintype "gear"
+      total_cost_in_cents 100
+      instructions "gear_prep instructions"
+
+      trait :gear_human do
+        prep_subtype "gear_human"
+      end
+
+      trait :gear_pet do
+        prep_subtype "gear_pet"
+      end
+    end
   end
+
 end

--- a/spec/factories/user_preps.rb
+++ b/spec/factories/user_preps.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :user_prep do
     user
     # user_id 1
-    prep_type "plan"
+    prep_maintype "plan"
     total_cost_in_cents 1
     completed false
     instructions "placeholder instructions"
@@ -10,7 +10,7 @@ FactoryGirl.define do
     trait :home_prep do
     # factory :home_user_prep do
       # user_id 1
-      prep_type "home"
+      prep_maintype "home"
       keyword "foundation"
       instructions "anchor home frame to foundation"
     end

--- a/spec/factories/user_preps.rb
+++ b/spec/factories/user_preps.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     user
     # user_id 1
     prep_maintype "plan"
+    prep_subtype "plan"
     total_cost_in_cents 1
     completed false
     instructions "placeholder instructions"

--- a/spec/models/preparation_spec.rb
+++ b/spec/models/preparation_spec.rb
@@ -12,8 +12,8 @@ describe Preparation, type: :model do
         expect(prep.errors.messages[:keyword]).to include("has already been taken")
       end
 
-      it "when prep_type is missing" do
-        new_prep = build(:preparation, prep_type: nil)
+      it "when prep_maintype is missing" do
+        new_prep = build(:preparation, prep_maintype: nil)
         expect(new_prep.valid?).to eq false
       end
 

--- a/spec/models/user_prep_spec.rb
+++ b/spec/models/user_prep_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
+require 'pry'
 
 describe UserPrep, type: :model do
   let(:generic_user_prep) { create(:user_prep) }
-  let(:home_prep)    { create(:home_prep) }
+  let(:home_prep) { create(:home_prep) }
 
   describe ".validates" do
     context "is invalid" do
@@ -19,18 +20,22 @@ describe UserPrep, type: :model do
       end
 
       it "when a prep with this keyword already exists for this User" do
-        # instantiate first factory as a home_prep
-        home_prep = create(:home_prep)
-        # stub out a duplicate home_prep with a redundant keyword
-        duplicate_home_prep = build_stubbed(:home_prep)
+        home_prep = create(:home_prep)                  # instantiate first factory as a home_prep
+        duplicate_home_prep = build_stubbed(:home_prep) # stub out a duplicate home_prep with a redundant keyword
         duplicate_home_prep.valid?
         expect(duplicate_home_prep.errors.messages[:keyword]).to include("has already been taken")
       end
 
-      it "is assigned a prep_type that is not one of home_/gear_/plan_prep" do
+      it "is assigned a prep_maintype that is not one of home_/gear_/plan_prep" do
         improperly_assigned_user_prep = build(:user_prep, prep_maintype: "food")
         improperly_assigned_user_prep.valid?
         expect(improperly_assigned_user_prep.errors.messages[:prep_maintype]).to include("is not included in the list")
+      end
+
+      it "is assigned an invalid prep_subtype" do
+        improperly_assigned_user_prep = build(:user_prep, prep_subtype: "wrong")
+        improperly_assigned_user_prep.valid?
+        expect(improperly_assigned_user_prep.errors.messages[:prep_subtype]).to include("is not included in the list")
       end
     end
   end

--- a/spec/models/user_prep_spec.rb
+++ b/spec/models/user_prep_spec.rb
@@ -28,9 +28,9 @@ describe UserPrep, type: :model do
       end
 
       it "is assigned a prep_type that is not one of home_/gear_/plan_prep" do
-        improperly_assigned_user_prep = build(:user_prep, prep_type: "food")
+        improperly_assigned_user_prep = build(:user_prep, prep_maintype: "food")
         improperly_assigned_user_prep.valid?
-        expect(improperly_assigned_user_prep.errors.messages[:prep_type]).to include("is not included in the list")
+        expect(improperly_assigned_user_prep.errors.messages[:prep_maintype]).to include("is not included in the list")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,5 +47,36 @@ describe User, type: :model do
         end
       end
     end
+
+    describe "#people_in_household" do
+      context "is single" do
+        it "returns 1" do
+          expect(user.people_in_household).to eq 1
+        end
+      end
+
+      context "has two human dependents" do
+        it "returns 3" do
+          dependent_spouse = create(:dependent, :human, name: "spouse", user_id: user.id)
+          dependent_child = create(:dependent, :human, name: "child", user_id: user.id)
+          expect(user.people_in_household).to eq 3
+        end
+      end
+    end
+
+    describe "#pets_in_household" do
+      context "owns no pets" do
+        it "returns nil" do
+          expect(user.pets_in_household).to eq 0
+        end
+      end
+
+      context "owns a single pet" do
+        it "returns 1" do
+          depenent_pet = create(:dependent, :pet, user_id: user.id)
+          expect(user.pets_in_household).to eq 1
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Lots of updates in here. Bottom-line is I made it so that a User can add/remove/update Dependents (people & pets) and the user_preps that pertain to these Dependent updates will A) be created and/or B) be updated as Dependents change. User_preps with variable quantities and total costs will change to reflect the number of dependents, and those that don't vary with Dependents will stay the same. User can also update the # of days they want to be covered. There is a decent amount of test coverage for this new functionality.