### PR TITLE
020-generate-preps-refactor

### DIFF
--- a/app/controllers/contact_assessment_controller.rb
+++ b/app/controllers/contact_assessment_controller.rb
@@ -36,9 +36,13 @@ class ContactAssessmentController < ApplicationController
   def destroy
     @contact = Contact.find(params[:id])
     @contact.destroy
-    current_user.destroy_contact_userpreps if !current_user.has_contacts? #clean out UserPreps for Contacts if there are no Contacts.
+    destroy_contact_userpreps if !current_user.has_contacts? #clean out UserPreps for Contacts if there are no Contacts.
     flash[:notice] = "Contact Deleted"
     redirect_to user_path(current_user.id)
+  end
+
+  def destroy_contact_userpreps
+    UserPrep.where(prep_subtype: "plan_contact", user_id: current_user.id).destroy_all
   end
 
   def generate_contact_preps(user)

--- a/app/controllers/dependent_assessment_controller.rb
+++ b/app/controllers/dependent_assessment_controller.rb
@@ -36,6 +36,9 @@ class DependentAssessmentController < ApplicationController
   def destroy
     @dependent = Dependent.find(params[:id])
     destroy_dependent_zones(@dependent.id)
+    if @dependent.human == false
+      UserPrep.where(user_id: current_user.id, prep_subtype: 'gear_pet').destroy_all
+    end
     @dependent.destroy
     generate_dependent_preps(current_user)
       # re-run this method so that user_preps with prep_subtype gear_pet and

--- a/app/controllers/dependent_assessment_controller.rb
+++ b/app/controllers/dependent_assessment_controller.rb
@@ -48,10 +48,13 @@ class DependentAssessmentController < ApplicationController
 
   def generate_dependent_preps(user)
     @pb = UserPrepBuilder.new(user)
-    @pb.generate_preps("gear_pet", options = {consumer_multiplier: user.pets_in_household}) if user.pets_in_household > 0
     @pb.generate_preps("gear_human", options = {consumer_multiplier: user.people_in_household})
-    # @pb.generate_preps("plan")
-    # @pb.generate_preps("zone") ???
+    @pb.generate_preps("gear_check")
+    @pb.generate_preps("plan_dependent_human")
+    if user.pets_in_household > 0
+      @pb.generate_preps("gear_pet", options = {consumer_multiplier: user.pets_in_household})
+      @pb.generate_preps("plan_dependent_pet")
+    end
   end
 
   def destroy_dependent_zones(dependent_id)

--- a/app/controllers/dependent_assessment_controller.rb
+++ b/app/controllers/dependent_assessment_controller.rb
@@ -38,6 +38,7 @@ class DependentAssessmentController < ApplicationController
     destroy_dependent_zones(@dependent.id)
     if @dependent.human == false
       UserPrep.where(user_id: current_user.id, prep_subtype: 'gear_pet').destroy_all
+      # TODO: make sure this captures all user_preps for pets (not just gear_pet)
     end
     @dependent.destroy
     generate_dependent_preps(current_user)

--- a/app/controllers/home_assessment_controller.rb
+++ b/app/controllers/home_assessment_controller.rb
@@ -25,5 +25,6 @@ class HomeAssessmentController < ApplicationController
     @pb.generate_preps("home_interior") # generic stage:before home preps regardless of house/apt/etc.
     @pb.generate_preps("home_structure") if @home.is_house # home preps that a homeowner can work on but renter likely cannot.
     @pb.generate_preps("home_check")    # generic stage:after preps for all home types
+    @pb.generate_preps("plan_home")
   end
 end

--- a/app/controllers/home_assessment_controller.rb
+++ b/app/controllers/home_assessment_controller.rb
@@ -4,6 +4,7 @@ class HomeAssessmentController < ApplicationController
     @home.update_db_values(params)
     destroy_house_preps if !@home.is_house # have to call this before @save in order to return a value from .changed method below
     if @home.save
+      generate_home_preps(current_user, @home)
       flash[:success] = "Home Updated"
       redirect_to user_path(current_user.id) # TODO: replace redirect w/ AJAX
     elsif @home.errors

--- a/app/controllers/home_assessment_controller.rb
+++ b/app/controllers/home_assessment_controller.rb
@@ -2,8 +2,8 @@ class HomeAssessmentController < ApplicationController
   def update_home
     @home ||= Home.load_home(current_user)
     @home.update_db_values(params)
+    destroy_house_preps if !@home.is_house # have to call this before @save in order to return a value from .changed method below
     if @home.save
-      generate_home_preps(current_user, @home)
       flash[:success] = "Home Updated"
       redirect_to user_path(current_user.id) # TODO: replace redirect w/ AJAX
     elsif @home.errors
@@ -26,5 +26,13 @@ class HomeAssessmentController < ApplicationController
     @pb.generate_preps("home_structure") if @home.is_house # home preps that a homeowner can work on but renter likely cannot.
     @pb.generate_preps("home_check")    # generic stage:after preps for all home types
     @pb.generate_preps("plan_home")
+    destroy_house_preps if !@home.is_house?
+  end
+
+  def destroy_house_preps
+    if @home.changed == ["is_house"]
+      up = UserPrep.where(user_id: current_user.id, prep_subtype: 'home_structure')
+      up.destroy_all
+    end
   end
 end

--- a/app/controllers/home_assessment_controller.rb
+++ b/app/controllers/home_assessment_controller.rb
@@ -22,7 +22,8 @@ class HomeAssessmentController < ApplicationController
 
   def generate_home_preps(user, home)
     @pb = UserPrepBuilder.new(user)
-    @pb.generate_preps("home_interior") # generic home preps regardless of house/apt/etc.
-    @pb.generate_preps("home_structure") if @home.is_house
+    @pb.generate_preps("home_interior") # generic stage:before home preps regardless of house/apt/etc.
+    @pb.generate_preps("home_structure") if @home.is_house # home preps that a homeowner can work on but renter likely cannot.
+    @pb.generate_preps("home_check")    # generic stage:after preps for all home types
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,6 +10,7 @@ class SessionsController < ApplicationController
       flash[:error] = 'Account does not exist'
     elsif @user.authenticate(params[:password])
       session[:user_id] = @user.id
+      @user.generate_all_user_preps
       redirect_to root_path
     else
       redirect_to root_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,20 +31,13 @@ class UsersController < ApplicationController
     else
       @user = current_user
     end
+    current_user.generate_all_user_preps
     load_assessment_data
   end
 
   def update
-    current_user.generate_all_user_preps
-    
     current_user.update(user_params) if user_params # update days_to_cover from users/show view, if this method was triggered from submitting that form.
-    generate_generic_user_preps(current_user)
-    d = DependentAssessmentController.new
-    d.generate_dependent_preps(current_user)
-    # re-run UserPrepBuilder (via DependentAssessmentController) for all of this
-    # user's UserPreps where total_cost varies based on user's # of days_to_cover
-    # TODO: run this same check but using a method on the user or user's
-    # UserPreps, not through DependentAssessmentController.
+    current_user.generate_all_user_preps # regenerate all preps so that those with variable quantities impacted by changing days_to_cover are updated.
     flash[:success] = "User Updated"
     redirect_to user_path(current_user)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     @user.admin = false
+    @user.days_to_cover = 3 # default
     if @user.save
       session[:user_id] = @user.id
       redirect_to user_path(id: @user.id)
@@ -34,7 +35,8 @@ class UsersController < ApplicationController
   end
 
   def update
-    current_user.update(user_params)
+    current_user.update(user_params) if user_params # update days_to_cover from users/show view, if this method was triggered from submitting that form.
+    generate_generic_user_preps(current_user)
     d = DependentAssessmentController.new
     d.generate_dependent_preps(current_user)
     # re-run UserPrepBuilder (via DependentAssessmentController) for all of this
@@ -57,6 +59,11 @@ class UsersController < ApplicationController
     @zone = Zone.new
     @contact = Contact.new
     # ^^ same as above comment, but for Zones & Contacts
+  end
+
+  def generate_generic_user_preps(user)
+    @pb = UserPrepBuilder.new(user)
+    @pb.generate_preps("plan_check")
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -56,11 +56,6 @@ class UsersController < ApplicationController
     # ^^ same as above comment, but for Zones & Contacts
   end
 
-  def generate_generic_user_preps(user)
-    @pb = UserPrepBuilder.new(user)
-    @pb.generate_preps("plan_check")
-  end
-
   private
   def user_params
     params.require(:user).permit(:username, :email, :password, :password_confirmation, :days_to_cover)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,6 +35,8 @@ class UsersController < ApplicationController
   end
 
   def update
+    current_user.generate_all_user_preps
+    
     current_user.update(user_params) if user_params # update days_to_cover from users/show view, if this method was triggered from submitting that form.
     generate_generic_user_preps(current_user)
     d = DependentAssessmentController.new

--- a/app/controllers/zone_assessment_controller.rb
+++ b/app/controllers/zone_assessment_controller.rb
@@ -36,6 +36,7 @@ class ZoneAssessmentController < ApplicationController
   def destroy
     @zone = Zone.find(params[:id])
     @zone.destroy
+    destroy_zone_userpreps if !current_user.has_zones?
     # generate_zone_preps(current_user) # NB: commented out for now because currently no plan_zone UserPreps vary based on # of zones.
     flash[:notice] = "Zone Deleted"
     redirect_to user_path(current_user.id)
@@ -53,6 +54,10 @@ class ZoneAssessmentController < ApplicationController
       # the options hash can carry the load of carrying & creating dynamic information.
     # @pb.generate_preps("plan_zone_humans") if user.has_dependents?
     # @pb.generate_preps("plan_zone_pets") if user.pets_in_household > 0
+  end
+
+  def destroy_zone_userpreps
+    UserPrep.where(prep_subtype: "plan_zone", user_id: current_user.id).destroy_all
   end
 
   private

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -27,6 +27,10 @@ class Home < ApplicationRecord
     # self.filter_house_specific_fields(params)
   end
 
+  def is_house?
+    self.is_house ? true : false
+  end
+
   # def filter_house_specific_fields(params)
   #   if self.is_house == false
   #     self.fdn_bolted         = nil

--- a/app/models/preparation.rb
+++ b/app/models/preparation.rb
@@ -2,6 +2,6 @@ class Preparation < ApplicationRecord
   include ActiveModel::Dirty # for tracking changes of attrs due to CSV import
 
   validates_presence_of :prep_maintype, :keyword, :instructions, :tracker_id
-  validates_uniqueness_of :keyword, :instructions
+  validates_uniqueness_of :keyword, :instructions, :tracker_id
   validates_inclusion_of :stage, in: %w( before during after )
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,4 +32,9 @@ class User < ApplicationRecord
   def destroy_contact_userpreps
     UserPrep.where(prep_subtype: "plan_contact", user_id: self.id).destroy_all
   end
+
+  def generate_all_user_preps
+    @pb = UserPrepBuilder.new(self)
+    @pb.generate_all_user_preps
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,10 +29,6 @@ class User < ApplicationRecord
     true if self.contacts.count > 0
   end
 
-  def destroy_contact_userpreps
-    UserPrep.where(prep_subtype: "plan_contact", user_id: self.id).destroy_all
-  end
-
   def generate_all_user_preps
     @pb = UserPrepBuilder.new(self)
     @pb.generate_all_user_preps

--- a/app/models/user_prep.rb
+++ b/app/models/user_prep.rb
@@ -5,7 +5,7 @@ class UserPrep < ApplicationRecord
   validates_inclusion_of :prep_subtype, in: %w(
     home_structure home_interior home_check
     gear_human gear_pet gear_check
-    plan_home plan_dependent plan_zone plan_contact plan_check
+    plan_home plan_dependent_human plan_dependent_pet plan_zone plan_contact plan_check
   )
   validates_inclusion_of :stage, in: %w( before during after )
   belongs_to :user

--- a/app/models/user_prep_builder.rb
+++ b/app/models/user_prep_builder.rb
@@ -2,10 +2,39 @@ class UserPrepBuilder
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  attr_accessor :user_id
+  attr_accessor :user_id,
+                :constant_quantity_prep_subtypes,
+                :variable_quantity_prep_subtypes
 
   def initialize(user)
+    @user    = user
     @user_id = user.id
+    @variable_quantity_prep_subtypes = %w(
+      gear_human gear_pet
+    )
+    @constant_quantity_prep_subtypes = %w(
+      home_structure home_interior home_check
+      gear_check
+      plan_home plan_dependent_human plan_dependent_pet plan_zone plan_contact plan_check
+    )
+  end
+
+  def generate_all_user_preps
+    self.generate_constant_quantity_user_preps
+    self.generate_variable_quantity_user_preps
+  end
+
+  def generate_constant_quantity_user_preps
+    @constant_quantity_prep_subtypes.each do |prep_subtype|
+      self.generate_preps(prep_subtype)
+    end
+  end
+
+  def generate_variable_quantity_user_preps
+    self.generate_preps("gear_human", options = {consumer_multiplier: @user.people_in_household})
+    if @user.pets_in_household > 0
+      self.generate_preps("gear_pet", options = {consumer_multiplier: @user.pets_in_household})
+    end
   end
 
   def generate_preps(prep_subtype, options = nil)

--- a/app/models/user_prep_builder.rb
+++ b/app/models/user_prep_builder.rb
@@ -1,4 +1,3 @@
-
 class UserPrepBuilder
   include ActiveModel::Model
   include ActiveModel::Validations

--- a/app/models/user_prep_builder.rb
+++ b/app/models/user_prep_builder.rb
@@ -4,28 +4,57 @@ class UserPrepBuilder
 
   attr_accessor :user_id,
                 :constant_quantity_prep_subtypes,
-                :variable_quantity_prep_subtypes
+                :variable_quantity_prep_subtypes,
+                :home_prep_subtypes,
+                :dependent_prep_subtypes,
+                :contact_prep_subtypes,
+                :zone_prep_subtypes
 
   def initialize(user)
     @user    = user
     @user_id = user.id
+    @home_prep_subtypes = %w(
+      home_interior home_check plan_home
+    )
+    @house_prep_subtypes = %w(
+      home_structure
+    )
+    @dependent_human_prep_subtypes = %w(
+      plan_dependent_human
+    )
+    @dependent_pet_prep_subtypes = %w(
+      plan_dependent_pet
+    )
     @variable_quantity_prep_subtypes = %w(
       gear_human gear_pet
     )
-    @constant_quantity_prep_subtypes = %w(
-      home_structure home_interior home_check
-      gear_check
-      plan_home plan_dependent_human plan_dependent_pet plan_zone plan_contact plan_check
+    @contact_prep_subtypes = %w(
+      plan_contact
+    )
+    @zone_prep_subtypes = %w(
+      plan_zone
+    )
+    @generic_prep_subtypes = %w(
+      plan_check
     )
   end
 
   def generate_all_user_preps
-    self.generate_constant_quantity_user_preps
+    # generate ceratin user_preps conditionally based on the user's associations
+    self.generate_constant_quantity_user_preps(@house_prep_subtypes) if @user.home && @user.home.is_house == true
+    self.generate_constant_quantity_user_preps(@dependent_human_prep_subtypes) if @user.people_in_household > 1
+    self.generate_constant_quantity_user_preps(@dependent_pet_prep_subtypes) if @user.pets_in_household > 0
+    self.generate_constant_quantity_user_preps(@contact_prep_subtypes) if @user.has_contacts?
+    self.generate_constant_quantity_user_preps(@zone_prep_subtypes) if @user.has_zones?
+    # generate user_preps common to all users
+    self.generate_constant_quantity_user_preps(@home_prep_subtypes)
+    self.generate_constant_quantity_user_preps(@generic_prep_subtypes)
+    # generate user_preps where variable quantity affects total_cost_in_cents
     self.generate_variable_quantity_user_preps
   end
 
-  def generate_constant_quantity_user_preps
-    @constant_quantity_prep_subtypes.each do |prep_subtype|
+  def generate_constant_quantity_user_preps(prep_subtype_array)
+    prep_subtype_array.each do |prep_subtype|
       self.generate_preps(prep_subtype)
     end
   end

--- a/app/views/layouts/forms/_home_assessment_form.html.erb
+++ b/app/views/layouts/forms/_home_assessment_form.html.erb
@@ -3,7 +3,7 @@
   <p class="description description-form">
     Enter details about your home.
   </p>
-  <%= form_for @home, url: update_home_path do |f| %>
+  <%= form_for @home, url: update_home_path, method: :patch do |f| %>
     <div class="form-group">
       <%= f.label :address, "Street Address" %>
       <%= f.text_field :address %>

--- a/spec/factories/preparations.rb
+++ b/spec/factories/preparations.rb
@@ -13,6 +13,7 @@ FactoryGirl.define do
       keyword "meetup_neighborhood"
       instructions "Identify a neighborhood meeting place"
       variable_quantity_type "N/A"
+      tracker_id 2
     end
 
     factory :home_prep do
@@ -22,6 +23,7 @@ FactoryGirl.define do
       instructions "anchor home frame to foundation"
       base_cost_in_cents 400000
       variable_quantity_type "by_user"
+      tracker_id 3
     end
 
     factory :gear_human do
@@ -31,6 +33,7 @@ FactoryGirl.define do
       instructions "put a headlamp next to bedside of each person in home"
       base_cost_in_cents 1500
       variable_quantity_type "by_dependent"
+      tracker_id 4
     end
 
     factory :gear_pet do
@@ -40,6 +43,7 @@ FactoryGirl.define do
       instructions "nonperishable pet food"
       base_cost_in_cents 200
       variable_quantity_type "by_day"
+      tracker_id 5
     end
   end
 end

--- a/spec/models/preparation_spec.rb
+++ b/spec/models/preparation_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Preparation, type: :model do
-  let(:home_prep) { create(:home_prep) }
   let(:prep) { create(:preparation) }
+  let(:home_prep) { create(:home_prep) }
 
   describe ".validates" do
     context "is invalid" do
@@ -26,6 +26,12 @@ describe Preparation, type: :model do
         new_prep = build(:preparation, stage: nil)
         new_prep.valid?
         expect(new_prep.errors.messages[:stage]).to include("is not included in the list")
+      end
+
+      it "uses a duplicate tracker_id" do
+        new_prep = build(:preparation, tracker_id: home_prep.tracker_id)
+        new_prep.valid?
+        expect(new_prep.errors.messages[:tracker_id]).to include("has already been taken")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -97,18 +97,19 @@ describe User, type: :model do
       end
     end
 
-    describe "#destroy_contact_userpreps" do
-      context "has one contact" do
-        it "removes UserPreps with prep_subtype: 'plan_contact'" do
-          contact = create(:contact, user_id: user.id)
-          prep = create(:plan_prep, prep_subtype: "plan_contact")
-          upb = UserPrepBuilder.new(user)
-          upb.generate_preps('plan_contact')
-          expect(user.user_preps.count).to eq 1
-          user.destroy_contact_userpreps
-          expect(user.user_preps.count).to eq 0
-        end
-      end
-    end
+    # NB: moved this method to contact_assessment_controller but holding on specs for said controller
+    # describe "#destroy_contact_userpreps" do
+    #   context "has one contact" do
+    #     it "removes UserPreps with prep_subtype: 'plan_contact'" do
+    #       contact = create(:contact, user_id: user.id)
+    #       prep = create(:plan_prep, prep_subtype: "plan_contact")
+    #       upb = UserPrepBuilder.new(user)
+    #       upb.generate_preps('plan_contact')
+    #       expect(user.user_preps.count).to eq 1
+    #       user.destroy_contact_userpreps
+    #       expect(user.user_preps.count).to eq 0
+    #     end
+    #   end
+    # end
   end
 end


### PR DESCRIPTION
A variety of refactors regarding Preparations, UserPreps, and how these stay in sync as both admin & users interact with the app. 

Most important refactor is the logic for how UserPreps are generated:
- all UserPreps are refreshed/regenerated when a user signs in / visits their profile page – this ensures that when new Preparations are loaded on the admin side (per ticket 018) their corresponding UserPreps will be loaded whenever a user next visits the site. 
- certain prep_subtypes are deleted if the models that led to their creation (dependent/zone/contact) are also destroyed
- all prep_subtypes are accounted for

